### PR TITLE
Only request needed scopes

### DIFF
--- a/app/lib/atomic_lti/services/base.rb
+++ b/app/lib/atomic_lti/services/base.rb
@@ -17,8 +17,10 @@ module AtomicLti
         @deployment_id = deployment_id || token_deployment_id
       end
 
+      def scopes; end
+
       def headers(options = {})
-        @token ||= AtomicLti::Authorization.request_token(iss: @iss, deployment_id: @deployment_id)
+        @token ||= AtomicLti::Authorization.request_token(iss: @iss, deployment_id: @deployment_id, scopes: scopes)
         {
           "Authorization" => "Bearer #{@token['access_token']}",
         }.merge(options)

--- a/app/lib/atomic_lti/services/line_items.rb
+++ b/app/lib/atomic_lti/services/line_items.rb
@@ -6,7 +6,12 @@ module AtomicLti
       def endpoint(lti_token)
         url = lti_token.dig(AtomicLti::Definitions::AGS_CLAIM, "lineitems")
         raise AtomicLti::Exceptions::LineItemError, "Unable to access line items" unless url.present?
+
         url
+      end
+
+      def scopes
+        @lti_token&.dig(AtomicLti::Definitions::AGS_CLAIM, "scope")
       end
 
       # Helper method to generate a default set of attributes

--- a/app/lib/atomic_lti/services/names_and_roles.rb
+++ b/app/lib/atomic_lti/services/names_and_roles.rb
@@ -6,6 +6,10 @@ module AtomicLti
         super(lti_token: lti_token)
       end
 
+      def scopes
+        [AtomicLti::Definitions::NAMES_AND_ROLES_SCOPE]
+      end
+
       def endpoint
         url = @lti_token.dig(AtomicLti::Definitions::NAMES_AND_ROLES_CLAIM, "context_memberships_url")
         raise AtomicLti::Exceptions::NamesAndRolesError, "Unable to access names and roles" unless url.present?

--- a/app/lib/atomic_lti/services/results.rb
+++ b/app/lib/atomic_lti/services/results.rb
@@ -3,6 +3,10 @@ module AtomicLti
     # Canvas API docs: https://canvas.instructure.com/doc/api/result.html
     class Results < AtomicLti::Services::Base
 
+      def scopes
+        [AtomicLti::Definitions::AGS_SCOPE_RESULT]
+      end
+
       def list(line_item_id)
         url = "#{line_item_id}/results"
         HTTParty.get(url, headers: headers)

--- a/app/lib/atomic_lti/services/score.rb
+++ b/app/lib/atomic_lti/services/score.rb
@@ -10,6 +10,10 @@ module AtomicLti
         @id = id
       end
 
+      def scopes
+        [AtomicLti::Definitions::AGS_SCOPE_SCORE]
+      end
+
       def endpoint
         if id.blank?
           raise ::AtomicLti::Exceptions::ScoreError,

--- a/lib/atomic_lti.rb
+++ b/lib/atomic_lti.rb
@@ -18,7 +18,7 @@ module AtomicLti
   mattr_accessor :target_link_path_prefixes
   mattr_accessor :default_deep_link_path
   mattr_accessor :jwt_secret
-  mattr_accessor :scopes
+  mattr_accessor :scopes, default: AtomicLti::Definitions.scopes.join(" ")
 
   def self.get_deployments(iss:, deployment_ids:)
     AtomicLti::Deployment.where(iss: iss, deployment_id: deployment_ids)

--- a/spec/lib/atomic_lti/authorization_spec.rb
+++ b/spec/lib/atomic_lti/authorization_spec.rb
@@ -62,7 +62,7 @@ module AtomicLti
       it "throws an exception when the deployment can't be found" do
         mocks = setup_canvas_lti_advantage
         expect {
-          Authorization.client_assertion(iss: mocks[:iss], deployment_id: 'bad_id')
+          Authorization.client_assertion(iss: mocks[:iss], deployment_id: "bad_id")
         }.to raise_error(AtomicLti::Exceptions::NoLTIDeployment)
       end
 
@@ -119,16 +119,16 @@ module AtomicLti
       it "caches based on scopes" do
         mocks = setup_canvas_lti_advantage
         stub_canvas_token
-        token1 = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
-        token1 = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope1", "scope2"])
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope1", "scope2"])
         expect(WebMock).to have_requested(:post, AtomicLti::Definitions::CANVAS_AUTH_TOKEN_URL).twice
       end
 
       it "caches based on scopes without regard to order" do
         mocks = setup_canvas_lti_advantage
         stub_canvas_token
-        token1 = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope2", "scope1"])
-        token1 = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope1", "scope2"])
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope2", "scope1"])
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope1", "scope2"])
         expect(WebMock).to have_requested(:post, AtomicLti::Definitions::CANVAS_AUTH_TOKEN_URL).once
       end
 
@@ -144,7 +144,7 @@ module AtomicLti
       it "throws an exception when the deployment can't be found" do
         mocks = setup_canvas_lti_advantage
         expect {
-          Authorization.request_token(iss: mocks[:iss], deployment_id: 'bad_id')
+          Authorization.request_token(iss: mocks[:iss], deployment_id: "bad_id")
         }.to raise_error(AtomicLti::Exceptions::NoLTIDeployment)
       end
     end
@@ -153,7 +153,7 @@ module AtomicLti
       it "returns a token" do
         mocks = setup_canvas_lti_advantage
         stub_canvas_token
-        token = Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: 'scope1')
+        token = Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: "scope1")
         expect(token["expires_in"]).to be_present
       end
 
@@ -161,7 +161,7 @@ module AtomicLti
         mocks = setup_canvas_lti_advantage
         stub_canvas_token
         expect {
-          Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: 'bad_id', scopes: 'scope1')
+          Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: "bad_id", scopes: "scope1")
         }.to raise_error(AtomicLti::Exceptions::NoLTIDeployment)
       end
 
@@ -171,7 +171,7 @@ module AtomicLti
         deployment = AtomicLti::Deployment.find_by(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
         deployment.platform.destroy
         expect {
-          Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: 'scope1')
+          Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: "scope1")
         }.to raise_error(AtomicLti::Exceptions::NoLTIPlatform)
       end
     end

--- a/spec/lib/atomic_lti/authorization_spec.rb
+++ b/spec/lib/atomic_lti/authorization_spec.rb
@@ -86,11 +86,59 @@ module AtomicLti
     end
 
     describe "request_token" do
+      let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+      let(:cache) { Rails.cache }
+      before do
+        allow(Rails).to receive(:cache).and_return(memory_store)
+        Rails.cache.clear
+      end
       it "returns a request token" do
         mocks = setup_canvas_lti_advantage
         stub_canvas_token
         token = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
         expect(token["expires_in"]).to be_present
+      end
+
+      it "caches the token" do
+        mocks = setup_canvas_lti_advantage
+        stub_canvas_token
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+        expect(WebMock).to have_requested(:post, AtomicLti::Definitions::CANVAS_AUTH_TOKEN_URL).once
+      end
+
+      it "works without caching" do
+        mocks = setup_canvas_lti_advantage
+        stub_canvas_token
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+        Rails.cache.clear
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+        expect(WebMock).to have_requested(:post, AtomicLti::Definitions::CANVAS_AUTH_TOKEN_URL).twice
+      end
+
+      it "caches based on scopes" do
+        mocks = setup_canvas_lti_advantage
+        stub_canvas_token
+        token1 = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+        token1 = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope1", "scope2"])
+        expect(WebMock).to have_requested(:post, AtomicLti::Definitions::CANVAS_AUTH_TOKEN_URL).twice
+      end
+
+      it "caches based on scopes without regard to order" do
+        mocks = setup_canvas_lti_advantage
+        stub_canvas_token
+        token1 = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope2", "scope1"])
+        token1 = Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: ["scope1", "scope2"])
+        expect(WebMock).to have_requested(:post, AtomicLti::Definitions::CANVAS_AUTH_TOKEN_URL).once
+      end
+
+      it "caches based on deployment id" do
+        mocks = setup_canvas_lti_advantage
+        stub_canvas_token
+        AtomicLti::Deployment.create!(iss: @iss, deployment_id: "another_deployment", client_id: @client_id)
+        Authorization.request_token(iss: mocks[:iss], deployment_id: "another_deployment")
+        Authorization.request_token(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+        expect(WebMock).to have_requested(:post, AtomicLti::Definitions::CANVAS_AUTH_TOKEN_URL).twice
       end
 
       it "throws an exception when the deployment can't be found" do
@@ -105,7 +153,7 @@ module AtomicLti
       it "returns a token" do
         mocks = setup_canvas_lti_advantage
         stub_canvas_token
-        token = Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+        token = Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: 'scope1')
         expect(token["expires_in"]).to be_present
       end
 
@@ -113,7 +161,7 @@ module AtomicLti
         mocks = setup_canvas_lti_advantage
         stub_canvas_token
         expect {
-          Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: 'bad_id')
+          Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: 'bad_id', scopes: 'scope1')
         }.to raise_error(AtomicLti::Exceptions::NoLTIDeployment)
       end
 
@@ -123,7 +171,7 @@ module AtomicLti
         deployment = AtomicLti::Deployment.find_by(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
         deployment.platform.destroy
         expect {
-          Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: mocks[:deployment_id])
+          Authorization.request_token_uncached(iss: mocks[:iss], deployment_id: mocks[:deployment_id], scopes: 'scope1')
         }.to raise_error(AtomicLti::Exceptions::NoLTIPlatform)
       end
     end

--- a/spec/lib/atomic_lti/services/line_items_spec.rb
+++ b/spec/lib/atomic_lti/services/line_items_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe AtomicLti::Services::LineItems do
   end
 
   describe "list" do
+    it "requests all scopres in the token" do
+      expect(AtomicLti::Authorization).to receive(:request_token).
+        with(hash_including({ scopes: match_array(@lti_token[AtomicLti::Definitions::AGS_CLAIM]["scope"]) })).
+        and_return("token")
+      stub_line_items_list
+      @line_item.list
+    end
+
     it "lists all line items in the course" do
       stub_line_items_list
       line_items = @line_item.list

--- a/spec/lib/atomic_lti/services/names_and_roles_spec.rb
+++ b/spec/lib/atomic_lti/services/names_and_roles_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe AtomicLti::Services::NamesAndRoles do
       stub_names_and_roles_list
     end
 
+    it "requests only the names and roles scope" do
+      expect(AtomicLti::Authorization).to receive(:request_token).
+        with(hash_including({ scopes: [AtomicLti::Definitions::NAMES_AND_ROLES_SCOPE] })).
+        and_return("token")
+      names_and_roles_service = AtomicLti::Services::NamesAndRoles.new(lti_token: @lti_token)
+      names_and_roles_service.list
+    end
+
     it "lists users in the course and their roles" do
       names_and_roles_service = AtomicLti::Services::NamesAndRoles.new(lti_token: @lti_token)
       names_and_roles = JSON.parse(names_and_roles_service.list.body)

--- a/spec/lib/atomic_lti/services/results_spec.rb
+++ b/spec/lib/atomic_lti/services/results_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe AtomicLti::Services::Results do
   end
 
   describe "list" do
+    it "requests only the results scope" do
+      expect(AtomicLti::Authorization).to receive(:request_token).
+        with(hash_including({ scopes: [AtomicLti::Definitions::AGS_SCOPE_RESULT] })).
+        and_return("token")
+      stub_line_items_list
+      @results_service.list(@line_item_id)
+    end
     it "lists results for the specified line item" do
       stub_line_items_list
       results = JSON.parse(@results_service.list(@line_item_id).body)

--- a/spec/lib/atomic_lti/services/score_spec.rb
+++ b/spec/lib/atomic_lti/services/score_spec.rb
@@ -11,6 +11,21 @@ RSpec.describe AtomicLti::Services::Score do
   end
 
   describe "send" do
+    it "requests only the score scope" do
+      expect(AtomicLti::Authorization).to receive(:request_token).
+        with(hash_including({ scopes: [AtomicLti::Definitions::AGS_SCOPE_SCORE] })).
+        and_return("token")
+      stub_scores_create
+      score = @score_service.generate(
+        user_id: "cfca15d8-2958-4647-a33e-a7c4b2ddab2c",
+        score: 10,
+        max_score: 10,
+        comment: "Great job",
+        activity_progress: "Completed",
+        grading_progress: "FullyGraded",
+      )
+      @score_service.send(score)
+    end
     it "sends a score for the specified line item" do
       stub_scores_create
       score = @score_service.generate(


### PR DESCRIPTION
When making a service call, only request token scopes that are needed for the call. This allows us to support installs with some LTI Advantage services missing or disabled.  The caching logic is updated to take this into account, as we will potentially have several tokens cached for a single deployment, each with different scopes.