### PR TITLE
Reduce the CSRF cookie lifetime

### DIFF
--- a/lib/atomic_lti/open_id_middleware.rb
+++ b/lib/atomic_lti/open_id_middleware.rb
@@ -31,7 +31,7 @@ module AtomicLti
       )
       Rack::Utils.set_cookie_header!(
         headers, "open_id_#{state}",
-        { value: csrf_token, path: "/", max_age: 5.minutes, http_only: false, secure: true, same_site: "None" }
+        { value: csrf_token, path: "/", max_age: 1.minute, http_only: false, secure: true, same_site: "None" }
       )
 
       redirect_uri = [request.base_url, AtomicLti.oidc_redirect_path].join

--- a/spec/middleware/open_id_middleware_spec.rb
+++ b/spec/middleware/open_id_middleware_spec.rb
@@ -51,7 +51,7 @@ module AtomicLti
         expect(headers["Set-Cookie"]).
           to match("open_id_cookie_storage=1; path=/; max-age=31536000; secure; SameSite=None")
         expect(headers["Set-Cookie"]).
-          to match("open_id_state=csrf; path=/; max-age=300; secure; SameSite=None")
+          to match("open_id_state=csrf; path=/; max-age=60; secure; SameSite=None")
       end
 
       context "with cookies" do


### PR DESCRIPTION
This will help work around header size limitations when many launches are made in a short period of time.