### PR TITLE
Fix results service

### DIFF
--- a/app/lib/atomic_lti/services/results.rb
+++ b/app/lib/atomic_lti/services/results.rb
@@ -12,9 +12,8 @@ module AtomicLti
         HTTParty.get(url, headers: headers)
       end
 
-      def show(line_item_id, result_id)
-        url = "#{line_item_id}/results/#{result_id}"
-        HTTParty.get(url, headers: headers)
+      def show(result_id)
+        HTTParty.get(result_id, headers: headers)
       end
 
     end

--- a/spec/lib/atomic_lti/services/results_spec.rb
+++ b/spec/lib/atomic_lti/services/results_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe AtomicLti::Services::Results do
 
   describe "show" do
     it "gets specific result for the specified line item" do
-      stub_line_item_show
-      result_id = ""
-      results = JSON.parse(@results_service.show(@line_item_id, result_id).body)
+      stub_result_show
+      result_id = "https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results/101"
+      results = JSON.parse(@results_service.show(result_id).body)
       expect(results.empty?).to be false
     end
   end

--- a/spec/support/http_mocks.rb
+++ b/spec/support/http_mocks.rb
@@ -61,6 +61,14 @@ def stub_line_item_delete
     )
 end
 
+def stub_result_show
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/line_items/[0-9]+/results/[0-9]+|).
+    to_return(
+      status: 200,
+      body: "{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results/101\",\"scoreOf\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31\",\"userId\":\"6adc5f3a-27dd-4c27-82f0-c013930ccf6a\",\"resultScore\":10.0,\"resultMaximum\":10.0,\"comment\":\"You wrote the thing\"}",
+    )
+end
+
 # Scores
 def stub_scores_create
   stub_request(:post, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/line_items/[0-9]+/scores|).


### PR DESCRIPTION
Fetching a result didn't work as the result id is a fully qualified url
For https://www.pivotaltracker.com/story/show/185455003 as socialize uses the results service