### PR TITLE
Add list_all methods to names and roles, line items, and results services

### DIFF
--- a/app/lib/atomic_lti/exceptions.rb
+++ b/app/lib/atomic_lti/exceptions.rb
@@ -93,5 +93,8 @@ module AtomicLti
         super(msg)
       end
     end
+
+    class PaginationLimitExceeded < AtomicLtiException
+    end
   end
 end

--- a/app/lib/atomic_lti/paging_helper.rb
+++ b/app/lib/atomic_lti/paging_helper.rb
@@ -1,0 +1,40 @@
+module AtomicLti
+  module PagingHelper
+    MAX_PAGES = 200
+
+    def self.response_link_urls(response, *rels)
+      links = response.headers["link"]&.split(",") || []
+      urls = {}
+      rels.each do |rel|
+        urls[rel] = link_url(links, rel)
+      end
+      urls.values_at(*rels)
+    end
+
+    def self.link_url(links, rel)
+      matching_link = links.find { |link| link.include?("rel=\"#{rel}\"") }
+
+      return unless matching_link
+
+      matching_link.split(";")[0].gsub(/[\<\>\s]/, "")
+    end
+
+    def self.paginate_request(response, &block)
+      next_url, = response_link_urls(response, "next")
+      response = yield response, next_url
+
+      pages_fetched = 1;
+      while next_url
+        response = yield response, next_url
+        break if response.blank?
+
+        next_url, = response_link_urls(response, "next")
+
+        pages_fetched += 1
+        if pages_fetched > MAX_PAGES
+          raise AtomicLti::Exceptions::PaginationLimitExceeded
+        end
+      end
+    end
+  end
+end

--- a/app/lib/atomic_lti/paging_helper.rb
+++ b/app/lib/atomic_lti/paging_helper.rb
@@ -12,18 +12,18 @@ module AtomicLti
     end
 
     def self.link_url(links, rel)
-      matching_link = links.find { |link| link.include?("rel=\"#{rel}\"") }
+      matching_link = links.detect { |link| link.include?("rel=\"#{rel}\"") }
 
       return unless matching_link
 
-      matching_link.split(";")[0].gsub(/[\<\>\s]/, "")
+      matching_link.split(";")[0].gsub(/[<>\s]/, "")
     end
 
-    def self.paginate_request(response, &block)
+    def self.paginate_request(response)
       next_url, = response_link_urls(response, "next")
       response = yield response, next_url
 
-      pages_fetched = 1;
+      pages_fetched = 1
       while next_url
         response = yield response, next_url
         break if response.blank?

--- a/app/lib/atomic_lti/services/base.rb
+++ b/app/lib/atomic_lti/services/base.rb
@@ -26,12 +26,8 @@ module AtomicLti
       end
 
       def get_next_url(response)
-        link = response.headers["link"]
-        return nil if link.blank?
-
-        if url = link.split(",").detect { |l| l.split(";")[1].strip == 'rel="next"' }
-          url.split(";")[0].gsub(/[\<\>\s]/, "")
-        end
+        next_url, = AtomicLti::PagingHelper.response_link_urls(response, "next")
+        return next_url
       end
 
     end

--- a/app/lib/atomic_lti/services/base.rb
+++ b/app/lib/atomic_lti/services/base.rb
@@ -27,7 +27,7 @@ module AtomicLti
 
       def get_next_url(response)
         next_url, = AtomicLti::PagingHelper.response_link_urls(response, "next")
-        return next_url
+        next_url
       end
 
     end

--- a/app/lib/atomic_lti/services/line_items.rb
+++ b/app/lib/atomic_lti/services/line_items.rb
@@ -74,16 +74,10 @@ module AtomicLti
       end
 
       def list_all(query = {})
-        line_items = []
-        AtomicLti::PagingHelper.paginate_request(list(query)) do |response, next_url|
-          line_items += JSON.parse(response.body)
-
-          if next_url.present?
-            list(query, page_url: next_url)
-          end
+        AtomicLti::PagingHelper.paginate_request do |next_link|
+          result_page = list(query, page_url: next_link)
+          [JSON.parse(result_page.body), get_next_url(result_page)]
         end
-
-        line_items
       end
 
       # Get a specific line item

--- a/app/lib/atomic_lti/services/names_and_roles.rb
+++ b/app/lib/atomic_lti/services/names_and_roles.rb
@@ -61,6 +61,21 @@ module AtomicLti
         )
       end
 
+      def list_all(query: {})
+        members = []
+        base_response = list(query: query)
+        AtomicLti::PagingHelper.paginate_request(base_response) do |response, next_url|
+          members += JSON.parse(response.body)["members"]
+          if next_url.present?
+            list(query: query, page_url: next_url)
+          end
+        end
+
+        final_body = JSON.parse(base_response.body)
+        final_body["members"] = members
+        final_body
+      end
+
       def verify_received_user_names(names_and_roles_memberships)
         if names_and_roles_memberships&.body.present?
           members = JSON.parse(names_and_roles_memberships.body)["members"]

--- a/app/lib/atomic_lti/services/names_and_roles.rb
+++ b/app/lib/atomic_lti/services/names_and_roles.rb
@@ -62,18 +62,16 @@ module AtomicLti
       end
 
       def list_all(query: {})
-        members = []
-        base_response = list(query: query)
-        AtomicLti::PagingHelper.paginate_request(base_response) do |response, next_url|
-          members += JSON.parse(response.body)["members"]
-          if next_url.present?
-            list(query: query, page_url: next_url)
-          end
+        page_body = nil
+
+        members = AtomicLti::PagingHelper.paginate_request do |next_link|
+          result_page = list(query: query, page_url: next_link)
+          page_body = JSON.parse(result_page.body)
+          [page_body["members"], get_next_url(result_page)]
         end
 
-        final_body = JSON.parse(base_response.body)
-        final_body["members"] = members
-        final_body
+        page_body["members"] = members
+        page_body
       end
 
       def verify_received_user_names(names_and_roles_memberships)

--- a/app/lib/atomic_lti/services/results.rb
+++ b/app/lib/atomic_lti/services/results.rb
@@ -20,15 +20,10 @@ module AtomicLti
       end
 
       def list_all(line_item_id, query: {})
-        results = []
-        AtomicLti::PagingHelper.paginate_request(list(line_item_id, query: query)) do |response, next_url|
-          results += JSON.parse(response.body)
-          if next_url.present?
-            list(line_item_id, page_url: next_url)
-          end
+        AtomicLti::PagingHelper.paginate_request do |next_link|
+          result_page = list(line_item_id, query: query, page_url: next_link)
+          [JSON.parse(result_page.body), get_next_url(result_page)]
         end
-
-        results
       end
 
       def show(result_id)

--- a/app/lib/atomic_lti/services/results.rb
+++ b/app/lib/atomic_lti/services/results.rb
@@ -7,9 +7,28 @@ module AtomicLti
         [AtomicLti::Definitions::AGS_SCOPE_RESULT]
       end
 
-      def list(line_item_id)
-        url = "#{line_item_id}/results"
+      def list(line_item_id, query: {}, page_url: nil)
+        url = if page_url.present?
+                page_url
+              else
+                uri = Addressable::URI.parse("#{line_item_id}/results")
+                uri.query_values = (uri.query_values || {}).merge(query)
+                uri.to_str
+              end
+
         HTTParty.get(url, headers: headers)
+      end
+
+      def list_all(line_item_id, query: {})
+        results = []
+        AtomicLti::PagingHelper.paginate_request(list(line_item_id, query: query)) do |response, next_url|
+          results += JSON.parse(response.body)
+          if next_url.present?
+            list(line_item_id, page_url: next_url)
+          end
+        end
+
+        results
       end
 
       def show(result_id)

--- a/spec/lib/atomic_lti/paging_helper_spec.rb
+++ b/spec/lib/atomic_lti/paging_helper_spec.rb
@@ -41,11 +41,11 @@ describe AtomicLti::PagingHelper do
     end
 
     it "raises if it hits the pagination limit" do
-      expect {
-        AtomicLti::PagingHelper.paginate_request(response) do |response, next_url|
+      expect do
+        AtomicLti::PagingHelper.paginate_request(response) do |_, _|
           response
         end
-      }.to raise_error(AtomicLti::Exceptions::PaginationLimitExceeded)
+      end.to raise_error(AtomicLti::Exceptions::PaginationLimitExceeded)
     end
   end
 end

--- a/spec/lib/atomic_lti/paging_helper_spec.rb
+++ b/spec/lib/atomic_lti/paging_helper_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe AtomicLti::PagingHelper do
+  let(:link_header) do
+    '<https://www.example.com/api/v1/courses/:id/discussion_topics.json?opaqueA>; rel="current",' \
+    '<https://www.example.com/api/v1/courses/:id/discussion_topics.json?opaqueB>; rel="next",' \
+    '<https://www.example.com/api/v1/courses/:id/discussion_topics.json?opaqueC>; rel="first",' \
+    '<https://www.example.com/api/v1/courses/:id/discussion_topics.json?opaqueD>; rel="last"'
+  end
+  let(:response) do
+    OpenStruct.new(
+      headers: { "link" => link_header },
+    )
+  end
+
+  describe "response_link_urls" do
+    it "returns the requested links from the link header" do
+      current_link, last_link = described_class.response_link_urls(response, "current", "last")
+
+      expect(current_link).to eq("https://www.example.com/api/v1/courses/:id/discussion_topics.json?opaqueA")
+      expect(last_link).to eq("https://www.example.com/api/v1/courses/:id/discussion_topics.json?opaqueD")
+    end
+  end
+
+  describe "link_url" do
+    it "returns the requested link URL" do
+      expect(described_class.link_url(link_header.split(","), "next")).
+        to eq("https://www.example.com/api/v1/courses/:id/discussion_topics.json?opaqueB")
+    end
+  end
+
+  describe "paginate_request" do
+    it "yields the response and next_url to the block" do
+      yields = []
+      AtomicLti::PagingHelper.paginate_request(response) do |response, next_url|
+        yields.push([response, next_url])
+        nil
+      end
+
+      expect(yields.count).to eq 2
+    end
+
+    it "raises if it hits the pagination limit" do
+      expect {
+        AtomicLti::PagingHelper.paginate_request(response) do |response, next_url|
+          response
+        end
+      }.to raise_error(AtomicLti::Exceptions::PaginationLimitExceeded)
+    end
+  end
+end

--- a/spec/lib/atomic_lti/services/line_items_spec.rb
+++ b/spec/lib/atomic_lti/services/line_items_spec.rb
@@ -41,15 +41,14 @@ RSpec.describe AtomicLti::Services::LineItems do
     end
 
     it "adds a valid query string when a query argument is given" do
-      allow(HTTParty).to receive(:get).and_return(OpenStruct.new({
-        headers: {},
-        body: "[]"
-      }))
+      allow(HTTParty).to receive(:get).and_return(
+        OpenStruct.new({ headers: {}, body: "[]" })
+      )
       query = { resource_link_id: "6adc5f3a-27dd-4c27-82f0-c013930ccf6a" }
       @line_item.list_all(query)
 
       expect(HTTParty).to have_received(:get).with(
-        "#{@id_token_decoded.dig(AtomicLti::Definitions::AGS_CLAIM, "lineitems")}?#{query.to_query}",
+        "#{@id_token_decoded.dig(AtomicLti::Definitions::AGS_CLAIM, 'lineitems')}?#{query.to_query}",
         anything,
       )
     end

--- a/spec/lib/atomic_lti/services/line_items_spec.rb
+++ b/spec/lib/atomic_lti/services/line_items_spec.rb
@@ -27,6 +27,34 @@ RSpec.describe AtomicLti::Services::LineItems do
     end
   end
 
+  describe "list_all" do
+    it "lists all line items in the course across multiple pages" do
+      stub_line_items_list_all
+      line_items = @line_item.list_all
+      expect(line_items.count).to eq 8
+    end
+
+    it "lists all line items in the course in a single page" do
+      stub_line_items_list
+      line_items = @line_item.list_all
+      expect(line_items.count).to eq 4
+    end
+
+    it "adds a valid query string when a query argument is given" do
+      allow(HTTParty).to receive(:get).and_return(OpenStruct.new({
+        headers: {},
+        body: "[]"
+      }))
+      query = { resource_link_id: "6adc5f3a-27dd-4c27-82f0-c013930ccf6a" }
+      @line_item.list_all(query)
+
+      expect(HTTParty).to have_received(:get).with(
+        "#{@id_token_decoded.dig(AtomicLti::Definitions::AGS_CLAIM, "lineitems")}?#{query.to_query}",
+        anything,
+      )
+    end
+  end
+
   describe "show" do
     it "gets a specific line item" do
       stub_line_item_show

--- a/spec/lib/atomic_lti/services/line_items_spec.rb
+++ b/spec/lib/atomic_lti/services/line_items_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe AtomicLti::Services::LineItems do
 
     it "adds a valid query string when a query argument is given" do
       allow(HTTParty).to receive(:get).and_return(
-        OpenStruct.new({ headers: {}, body: "[]" })
+        OpenStruct.new({ headers: {}, body: "[]" }),
       )
       query = { resource_link_id: "6adc5f3a-27dd-4c27-82f0-c013930ccf6a" }
       @line_item.list_all(query)

--- a/spec/lib/atomic_lti/services/names_and_roles_spec.rb
+++ b/spec/lib/atomic_lti/services/names_and_roles_spec.rb
@@ -90,16 +90,19 @@ RSpec.describe AtomicLti::Services::NamesAndRoles do
     end
 
     it "adds a valid query string when a query argument is given" do
-      allow(HTTParty).to receive(:get).and_return(OpenStruct.new({
-        headers: {},
-        body: '{"members": []}'
-      }))
+      allow(HTTParty).to receive(:get).and_return(
+        OpenStruct.new({ headers: {}, body: '{"members": []}' })
+      )
       names_and_roles_service = AtomicLti::Services::NamesAndRoles.new(id_token_decoded: @id_token_decoded)
       query = { role: "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner" }
       names_and_roles_service.list_all(query: query)
 
+      membership_url = @id_token_decoded.dig(
+        AtomicLti::Definitions::NAMES_AND_ROLES_CLAIM,
+        "context_memberships_url",
+      )
       expect(HTTParty).to have_received(:get).with(
-        "#{@id_token_decoded.dig(AtomicLti::Definitions::NAMES_AND_ROLES_CLAIM, 'context_memberships_url')}?#{query.to_query}",
+        "#{membership_url}?#{query.to_query}",
         anything,
       )
     end

--- a/spec/lib/atomic_lti/services/names_and_roles_spec.rb
+++ b/spec/lib/atomic_lti/services/names_and_roles_spec.rb
@@ -73,4 +73,35 @@ RSpec.describe AtomicLti::Services::NamesAndRoles do
       end
     end
   end
+
+  describe "list_all" do
+    it "lists all memberships in the course across multiple pages" do
+      stub_names_and_roles_list_all
+      names_and_roles_service = AtomicLti::Services::NamesAndRoles.new(id_token_decoded: @id_token_decoded)
+      members = names_and_roles_service.list_all["members"]
+      expect(members.count).to eq 10
+    end
+
+    it "lists all memberships in the course in a single page" do
+      stub_names_and_roles_list
+      names_and_roles_service = AtomicLti::Services::NamesAndRoles.new(id_token_decoded: @id_token_decoded)
+      members = names_and_roles_service.list_all["members"]
+      expect(members.count).to eq 5
+    end
+
+    it "adds a valid query string when a query argument is given" do
+      allow(HTTParty).to receive(:get).and_return(OpenStruct.new({
+        headers: {},
+        body: '{"members": []}'
+      }))
+      names_and_roles_service = AtomicLti::Services::NamesAndRoles.new(id_token_decoded: @id_token_decoded)
+      query = { role: "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner" }
+      names_and_roles_service.list_all(query: query)
+
+      expect(HTTParty).to have_received(:get).with(
+        "#{@id_token_decoded.dig(AtomicLti::Definitions::NAMES_AND_ROLES_CLAIM, 'context_memberships_url')}?#{query.to_query}",
+        anything,
+      )
+    end
+  end
 end

--- a/spec/lib/atomic_lti/services/names_and_roles_spec.rb
+++ b/spec/lib/atomic_lti/services/names_and_roles_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe AtomicLti::Services::NamesAndRoles do
 
     it "adds a valid query string when a query argument is given" do
       allow(HTTParty).to receive(:get).and_return(
-        OpenStruct.new({ headers: {}, body: '{"members": []}' })
+        OpenStruct.new({ headers: {}, body: '{"members": []}' }),
       )
       names_and_roles_service = AtomicLti::Services::NamesAndRoles.new(id_token_decoded: @id_token_decoded)
       query = { role: "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner" }

--- a/spec/lib/atomic_lti/services/results_spec.rb
+++ b/spec/lib/atomic_lti/services/results_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe AtomicLti::Services::Results do
 
     it "adds a valid query string when a query argument is given" do
       allow(HTTParty).to receive(:get).and_return(
-        OpenStruct.new({ headers: {}, body: "[]" })
+        OpenStruct.new({ headers: {}, body: "[]" }),
       )
       query = { user_id: "6adc5f3a-27dd-4c27-82f0-c013930ccf6a" }
       @results_service.list_all(@line_item_id, query: query)

--- a/spec/lib/atomic_lti/services/results_spec.rb
+++ b/spec/lib/atomic_lti/services/results_spec.rb
@@ -19,10 +19,50 @@ RSpec.describe AtomicLti::Services::Results do
       stub_line_items_list
       @results_service.list(@line_item_id)
     end
+
     it "lists results for the specified line item" do
       stub_line_items_list
       results = JSON.parse(@results_service.list(@line_item_id).body)
       expect(results.empty?).to be false
+    end
+
+    it "adds a valid query string when a query argument is given" do
+      allow(HTTParty).to receive(:get)
+      query = { user_id: "6adc5f3a-27dd-4c27-82f0-c013930ccf6a" }
+      @results_service.list(@line_item_id, query: query)
+
+      expect(HTTParty).to have_received(:get).with(
+        "#{@line_item_id}/results?#{query.to_query}",
+        anything,
+      )
+    end
+  end
+
+  describe "list_all" do
+    it "lists all results for the specified line item across multiple pages" do
+      stub_result_list_all
+      results = @results_service.list_all(@line_item_id)
+      expect(results.count).to eq 2
+    end
+
+    it "lists all results for the specified line item in a single page" do
+      stub_result_list
+      results = @results_service.list_all(@line_item_id)
+      expect(results.count).to eq 1
+    end
+
+    it "adds a valid query string when a query argument is given" do
+      allow(HTTParty).to receive(:get).and_return(OpenStruct.new({
+        headers: {},
+        body: "[]"
+      }))
+      query = { user_id: "6adc5f3a-27dd-4c27-82f0-c013930ccf6a" }
+      @results_service.list_all(@line_item_id, query: query)
+
+      expect(HTTParty).to have_received(:get).with(
+        "#{@line_item_id}/results?#{query.to_query}",
+        anything,
+      )
     end
   end
 

--- a/spec/lib/atomic_lti/services/results_spec.rb
+++ b/spec/lib/atomic_lti/services/results_spec.rb
@@ -52,10 +52,9 @@ RSpec.describe AtomicLti::Services::Results do
     end
 
     it "adds a valid query string when a query argument is given" do
-      allow(HTTParty).to receive(:get).and_return(OpenStruct.new({
-        headers: {},
-        body: "[]"
-      }))
+      allow(HTTParty).to receive(:get).and_return(
+        OpenStruct.new({ headers: {}, body: "[]" })
+      )
       query = { user_id: "6adc5f3a-27dd-4c27-82f0-c013930ccf6a" }
       @results_service.list_all(@line_item_id, query: query)
 

--- a/spec/support/http_mocks.rb
+++ b/spec/support/http_mocks.rb
@@ -20,12 +20,50 @@ def stub_names_and_roles_list
     )
 end
 
+def stub_names_and_roles_list_all
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/names_and_roles$|).
+    to_return(
+      status: 200,
+      body: "{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles\",\"context\":{\"id\":\"af9b5e18fe251409be18e77253d918dcf22d156e\",\"label\":\"Intro Geology\",\"title\":\"Introduction to Geology - Ball\"},\"members\":[{\"status\":\"Active\",\"user_id\":\"cfca15d8-2958-4647-a33e-a7c4b2ddab2c\",\"name\":\"George Washington\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor\"]},{\"status\":\"Active\",\"user_id\":\"7c119130-88a1-4bc0-9dac-d5dab2569c58\",\"name\":\"James Madison\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Learner\"]},{\"status\":\"Active\",\"user_id\":\"8e5f9e00-1dc1-4cd9-b321-5bec4c891fe2\",\"name\":\"Benjamin Franklin\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Learner\"]},{\"status\":\"Active\",\"user_id\":\"abb134a1-58f1-42b2-84f7-78871b7ac6f6\",\"name\":\"John Adams\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Learner\"]},{\"status\":\"Active\",\"user_id\":\"2f4ade7b-29b2-4189-b338-e8ee036f15aa\",\"name\":\"Thomas Jefferson\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor\"]}]}",
+      headers: {
+        "link" => %{<https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles?opaqueA>; rel="current", <https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles?opaqueB>; rel="next", <https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles?opaqueC>; rel="first", <https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles?opaqueD>; rel="last"}
+      }
+    )
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/names_and_roles\?opaqueB|).
+    to_return(
+      status: 200,
+      body: "{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles\",\"context\":{\"id\":\"af9b5e18fe251409be18e77253d918dcf22d156e\",\"label\":\"Intro Geology\",\"title\":\"Introduction to Geology - Ball\"},\"members\":[{\"status\":\"Active\",\"user_id\":\"dfca15d8-2958-4647-a33e-a7c4b2ddab2c\",\"name\":\"Abraham Lincoln\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor\"]},{\"status\":\"Active\",\"user_id\":\"8c119130-88a1-4bc0-9dac-d5dab2569c58\",\"name\":\"Ulysses Grant\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Learner\"]},{\"status\":\"Active\",\"user_id\":\"9e5f9e00-1dc1-4cd9-b321-5bec4c891fe2\",\"name\":\"William Sherman\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Learner\"]},{\"status\":\"Active\",\"user_id\":\"bbb134a1-58f1-42b2-84f7-78871b7ac6f6\",\"name\":\"George McClellan\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Learner\"]},{\"status\":\"Active\",\"user_id\":\"3f4ade7b-29b2-4189-b338-e8ee036f15aa\",\"name\":\"Ambrose Burnside\",\"roles\":[\"http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor\"]}]}",
+      headers: {
+        "link" => %{<https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles?opaqueA>; rel="current", <https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles?opaqueC>; rel="first", <https://atomicjolt.instructure.com/api/lti/courses/3334/names_and_roles?opaqueD>; rel="last"}
+      }
+    )
+end
+
 # Line items
 def stub_line_items_list
   stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/line_items|).
     to_return(
       status: 200,
       body: "[{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/25\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-18 23:18:24 UTC\",\"resourceId\":\"1\",\"tag\":\"lti-advantage\",\"#{AtomicLti::Definitions::CANVAS_SUBMISSION_TYPE}\":{\"type\":\"external_tool\",\"external_tool_url\":\"https://helloworld.atomicjolt.xyz/lti_launches\"}},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/24\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-18 23:18:24 UTC\",\"resourceLinkId\":\"7c358941-9b49-45fd-be81-c222284d38d7\"},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/27\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-17 22:59:42 UTC\",\"resourceId\":\"1\",\"tag\":\"lti-advantage\",\"#{AtomicLti::Definitions::CANVAS_SUBMISSION_TYPE}\":{\"type\":\"external_tool\",\"external_tool_url\":\"https://helloworld.atomicjolt.xyz/lti_launches\"}},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/26\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-17 22:59:42 UTC\",\"resourceLinkId\":\"29ddee58-1636-4436-a5de-8c643695708f\"}]",
+    )
+end
+
+def stub_line_items_list_all
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/line_items$|).
+    to_return(
+      status: 200,
+      body: "[{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/25\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-18 23:18:24 UTC\",\"resourceId\":\"1\",\"tag\":\"lti-advantage\",\"#{AtomicLti::Definitions::CANVAS_SUBMISSION_TYPE}\":{\"type\":\"external_tool\",\"external_tool_url\":\"https://helloworld.atomicjolt.xyz/lti_launches\"}},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/24\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-18 23:18:24 UTC\",\"resourceLinkId\":\"7c358941-9b49-45fd-be81-c222284d38d7\"},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/27\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-17 22:59:42 UTC\",\"resourceId\":\"1\",\"tag\":\"lti-advantage\",\"#{AtomicLti::Definitions::CANVAS_SUBMISSION_TYPE}\":{\"type\":\"external_tool\",\"external_tool_url\":\"https://helloworld.atomicjolt.xyz/lti_launches\"}},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/26\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-17 22:59:42 UTC\",\"resourceLinkId\":\"29ddee58-1636-4436-a5de-8c643695708f\"}]",
+      headers: {
+        "link" => %{<https://atomicjolt.instructure.com/api/lti/courses/3334/line_items?opaqueA>; rel="current", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items?opaqueB>; rel="next", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items?opaqueC>; rel="first", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items?opaqueD>; rel="last"}
+      }
+    )
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/line_items\?opaqueB|).
+    to_return(
+      status: 200,
+      body: "[{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/125\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-18 23:18:24 UTC\",\"resourceId\":\"1\",\"tag\":\"lti-advantage\",\"#{AtomicLti::Definitions::CANVAS_SUBMISSION_TYPE}\":{\"type\":\"external_tool\",\"external_tool_url\":\"https://helloworld.atomicjolt.xyz/lti_launches\"}},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/124\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-18 23:18:24 UTC\",\"resourceLinkId\":\"7c358941-9b49-45fd-be81-c222284d38d7\"},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/127\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-17 22:59:42 UTC\",\"resourceId\":\"1\",\"tag\":\"lti-advantage\",\"#{AtomicLti::Definitions::CANVAS_SUBMISSION_TYPE}\":{\"type\":\"external_tool\",\"external_tool_url\":\"https://helloworld.atomicjolt.xyz/lti_launches\"}},{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/126\",\"scoreMaximum\":10.0,\"label\":\"LTI Advantage test item 2019-07-17 22:59:42 UTC\",\"resourceLinkId\":\"29ddee58-1636-4436-a5de-8c643695708f\"}]",
+      headers: {
+        "link" => %{<https://atomicjolt.instructure.com/api/lti/courses/3334/line_items?opaqueA>; rel="current", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items?opaqueC>; rel="first", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items?opaqueD>; rel="last"}
+      }
     )
 end
 
@@ -66,6 +104,33 @@ def stub_result_show
     to_return(
       status: 200,
       body: "{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results/101\",\"scoreOf\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31\",\"userId\":\"6adc5f3a-27dd-4c27-82f0-c013930ccf6a\",\"resultScore\":10.0,\"resultMaximum\":10.0,\"comment\":\"You wrote the thing\"}",
+    )
+end
+
+def stub_result_list
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/line_items/[0-9]+/results|).
+    to_return(
+      status: 200,
+      body: "[{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results/101\",\"scoreOf\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31\",\"userId\":\"6adc5f3a-27dd-4c27-82f0-c013930ccf6a\",\"resultScore\":10.0,\"resultMaximum\":10.0,\"comment\":\"You wrote the thing\"}]",
+    )
+end
+
+def stub_result_list_all
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/line_items/[0-9]+/results$|).
+    to_return(
+      status: 200,
+      body: "[{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results/101\",\"scoreOf\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31\",\"userId\":\"6adc5f3a-27dd-4c27-82f0-c013930ccf6a\",\"resultScore\":10.0,\"resultMaximum\":10.0,\"comment\":\"You wrote the thing\"}]",
+      headers: {
+        "link" => %{<https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results?opaqueA>; rel="current", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results?opaqueB>; rel="next", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results?opaqueC>; rel="first", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results?opaqueD>; rel="last"}
+      }
+    )
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/courses/[0-9]+/line_items/[0-9]+/results\?opaqueB|).
+    to_return(
+      status: 200,
+      body: "[{\"id\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results/201\",\"scoreOf\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31\",\"userId\":\"7adc5f3a-27dd-4c27-82f0-c013930ccf6a\",\"resultScore\":10.0,\"resultMaximum\":10.0,\"comment\":\"You wrote the thing\"}]",
+      headers: {
+        "link" => %{<https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results?opaqueA>; rel="current", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results?opaqueC>; rel="first", <https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results?opaqueD>; rel="last"}
+      }
     )
 end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185455003

Socialize needs to be able to list all line items handling pagination. This adds list_all where the spec says that pagination can exist for these three services.