### PR TITLE
Create partitioned cookies

### DIFF
--- a/lib/atomic_lti/open_id_middleware.rb
+++ b/lib/atomic_lti/open_id_middleware.rb
@@ -38,7 +38,8 @@ module AtomicLti
         { value: 1, path: "/", max_age: 1.minute, http_only: false, secure: true, same_site: "None", partitioned: true }
       )
 
-      # Ensure our cookies are partitioned.  This can be removed with Rack > 3.0.8
+      # Ensure our cookies are partitioned.  This can be removed once our Rack version
+      # understands the partitioned: argument above.
       headers[Rack::SET_COOKIE] = partition_cookies(headers[Rack::SET_COOKIE])
 
       redirect_uri = [request.base_url, AtomicLti.oidc_redirect_path].join

--- a/lib/atomic_lti/open_id_middleware.rb
+++ b/lib/atomic_lti/open_id_middleware.rb
@@ -31,12 +31,15 @@ module AtomicLti
       headers = { "Content-Type" => "text/html" }
       Rack::Utils.set_cookie_header!(
         headers, "#{OPEN_ID_COOKIE_PREFIX}storage",
-        { value: "1", path: "/", max_age: 365.days, http_only: false, secure: true, same_site: "None" }
+        { value: "1", path: "/", max_age: 365.days, http_only: false, secure: true, same_site: "None", partitioned: true }
       )
       Rack::Utils.set_cookie_header!(
         headers, "#{OPEN_ID_COOKIE_PREFIX}#{state}",
-        { value: 1, path: "/", max_age: 1.minute, http_only: false, secure: true, same_site: "None" }
+        { value: 1, path: "/", max_age: 1.minute, http_only: false, secure: true, same_site: "None", partitioned: true }
       )
+
+      # Ensure our cookies are partitioned.  This can be removed with Rack > 3.0.8
+      headers[Rack::SET_COOKIE] = partition_cookies(headers[Rack::SET_COOKIE])
 
       redirect_uri = [request.base_url, AtomicLti.oidc_redirect_path].join
       response_url = build_oidc_response(request, state, nonce, redirect_uri)
@@ -362,6 +365,31 @@ module AtomicLti
         originSupportBroken: !AtomicLti.set_post_message_origin,
         platformOIDCUrl: platform.oidc_url,
       }.compact
+    end
+
+    def partition_cookies(header)
+      # Some versions of rack add multiple cookies as a newline-separated string, and others
+      # as an array of strings.
+      case header
+      when String
+        header.split("\n").map do |cookie|
+          if !cookie.match? /partitioned/i
+            "#{cookie}; partitioned"
+          else
+            cookie
+          end
+        end.join("\n")
+      when Array
+        header.map do |cookie|
+          if !cookie.match? /partitioned/i
+            "#{cookie}; partitioned"
+          else
+            cookie
+          end
+        end
+      else
+        header
+      end
     end
   end
 end

--- a/spec/middleware/open_id_middleware_spec.rb
+++ b/spec/middleware/open_id_middleware_spec.rb
@@ -49,9 +49,9 @@ module AtomicLti
         )
         _status, headers, _response = subject.call(req_env)
         expect(headers["Set-Cookie"]).
-          to match("open_id_storage=1; path=/; max-age=31536000; secure; SameSite=None")
+          to match("open_id_storage=1; path=/; max-age=31536000; secure; SameSite=None; partitioned")
         expect(headers["Set-Cookie"]).
-          to match("open_id_state=1; path=/; max-age=60; secure; SameSite=None")
+          to match("open_id_state=1; path=/; max-age=60; secure; SameSite=None; partitioned")
       end
 
       context "with cookies" do


### PR DESCRIPTION
Create partitioned cookies.

Rack doesn't yet support partitioned cookies, so we fallback to adding the flag ourselves if we're on an older Rack version.

This PR should be compatible with a future Rack release having partitioned cookies:
https://github.com/rack/rack/pull/2131/files
