### PR TITLE
Fix listing results for moodle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :development, :test, :linter do
   gem "rubocop-rails"
   gem "rubocop-rspec"
   gem "webmock"
+  gem "ims-lti"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -13,12 +13,12 @@ end
 group :development, :test, :linter do
   gem "byebug"
   gem "factory_bot_rails"
+  gem "ims-lti"
   gem "rubocop"
   gem "rubocop-performance"
   gem "rubocop-rails"
   gem "rubocop-rspec"
   gem "webmock"
-  gem "ims-lti"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,13 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    ims-lti (2.3.4)
+      addressable (~> 2.5, >= 2.5.1)
+      builder (~> 3.2)
+      faraday (< 3.0)
+      json-jwt (~> 1.7)
+      rexml
+      simple_oauth (~> 0.3.1)
     json (2.6.3)
     json-jwt (1.16.3)
       activesupport (>= 4.2)
@@ -260,6 +267,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    simple_oauth (0.3.1)
     sqlite3 (1.6.2)
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.6.2-x86_64-linux)
@@ -290,6 +298,7 @@ DEPENDENCIES
   composite_primary_keys
   factory_bot_rails
   httparty
+  ims-lti
   json-jwt
   jwt (~> 2.7.0)
   launchy

--- a/app/lib/atomic_lti/services/results.rb
+++ b/app/lib/atomic_lti/services/results.rb
@@ -11,7 +11,7 @@ module AtomicLti
         url = if page_url.present?
                 page_url
               else
-                uri = Addressable::URI.parse("#{line_item_id}")
+                uri = Addressable::URI.parse(line_item_id)
                 uri.path = "#{uri.path}/results"
                 uri.query_values = (uri.query_values || {}).merge(query)
                 uri.to_str

--- a/app/lib/atomic_lti/services/results.rb
+++ b/app/lib/atomic_lti/services/results.rb
@@ -11,7 +11,8 @@ module AtomicLti
         url = if page_url.present?
                 page_url
               else
-                uri = Addressable::URI.parse("#{line_item_id}/results")
+                uri = Addressable::URI.parse("#{line_item_id}")
+                uri.path = "#{uri.path}/results"
                 uri.query_values = (uri.query_values || {}).merge(query)
                 uri.to_str
               end

--- a/spec/lib/atomic_lti/services/results_spec.rb
+++ b/spec/lib/atomic_lti/services/results_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe AtomicLti::Services::Results do
         anything,
       )
     end
+    
+    it "handles query params in the line item id" do
+      allow(HTTParty).to receive(:get).and_return(
+        OpenStruct.new({ headers: {}, body: "[]" }),
+      )
+      query = { user_id: "6adc5f3a-27dd-4c27-82f0-c013930ccf6a" }
+
+      line_item_id = "https://moodle.atomicjoltdevapps.com/mod/lti/services.php/12/lineitems/165/lineitem?type_id=16"
+      @results_service.list(line_item_id, query: query)
+
+      expect(HTTParty).to have_received(:get).with(
+        "https://moodle.atomicjoltdevapps.com/mod/lti/services.php/12/lineitems/165/lineitem/results?type_id=16&#{query.to_query}",
+        anything,
+      )
+    end
   end
 
   describe "list_all" do

--- a/spec/lib/atomic_lti/services/results_spec.rb
+++ b/spec/lib/atomic_lti/services/results_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe AtomicLti::Services::Results do
         anything,
       )
     end
-    
+
     it "handles query params in the line item id" do
       allow(HTTParty).to receive(:get).and_return(
         OpenStruct.new({ headers: {}, body: "[]" }),


### PR DESCRIPTION
Moodle line item ids have a query param, so we can't just append /results to the whole line item id, but instead need to add it to the path. Appending to the path is also what the spec says to do.

https://www.pivotaltracker.com/story/show/186732628