### PR TITLE
 Support launches across multiple hosts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atomic_lti (1.6.0)
+    atomic_lti (1.7.0)
       pg (~> 1.3)
       rails (~> 7.0)
 

--- a/app/lib/atomic_lti/lti.rb
+++ b/app/lib/atomic_lti/lti.rb
@@ -83,7 +83,9 @@ module AtomicLti
 
       # Validate that we are at the target_link_uri
       target_link_uri = decoded_token[AtomicLti::Definitions::TARGET_LINK_URI_CLAIM]
-      if validate_target_link_url && target_link_uri != requested_target_link_uri
+
+      if validate_target_link_url &&
+          !matching_uri?(target_link_uri, requested_target_link_uri, ignore_host: AtomicLti.update_target_link_host)
         errors.push(
           "LTI token target link uri '#{target_link_uri}' doesn't match url '#{requested_target_link_uri}'",
         )
@@ -122,6 +124,17 @@ module AtomicLti
       else
         decoded_token["aud"]
       end
+    end
+
+    def self.matching_uri?(target, actual, ignore_host:)
+      t = URI.parse(target)
+      a = URI.parse(actual)
+
+      t.scheme == a.scheme &&
+        t.path == a.path &&
+        t.query == a.query &&
+        t.fragment == a.fragment &&
+        (ignore_host || t.host == a.host)
     end
   end
 end

--- a/lib/atomic_lti.rb
+++ b/lib/atomic_lti.rb
@@ -32,6 +32,12 @@ module AtomicLti
   # requires this, but Canvas doesn't currently support it.
   mattr_accessor :set_post_message_origin, default: false
 
+  # Set to true to update the target link uri host to match the oidc redirect host.
+  # Enable this when a single LTI install needs to support launches across multiple hosts.
+  # Setting this avoids state validation problems on launch since state cookies and
+  # postMessage storage won't work across different hosts.
+  mattr_accessor :update_target_link_host, default: false
+
   mattr_accessor :privacy_policy_url, default: "#"
   mattr_accessor :privacy_policy_message, default: nil
 

--- a/lib/atomic_lti/open_id_middleware.rb
+++ b/lib/atomic_lti/open_id_middleware.rb
@@ -115,6 +115,13 @@ module AtomicLti
       target_link_uri = id_token_decoded[AtomicLti::Definitions::TARGET_LINK_URI_CLAIM] ||
         File.join("#{uri.scheme}://#{uri.host}", AtomicLti.default_deep_link_path)
 
+      target = URI.parse(target_link_uri)
+
+      # Optionally update the target link host to match the redirect host
+      if AtomicLti.update_target_link_host && target.host != uri.host
+        target.host = uri.host
+      end
+
       # We want to strip out the redirect path params from the request params
       # so that we can support having the redirect path be the same as the
       # launch path, only differentiated by a query parameter. This is needed
@@ -135,7 +142,7 @@ module AtomicLti
         template: "atomic_lti/shared/redirect",
         assigns: {
           launch_params: launch_params,
-          launch_url: target_link_uri,
+          launch_url: target,
         },
       )
 

--- a/lib/atomic_lti/version.rb
+++ b/lib/atomic_lti/version.rb
@@ -1,3 +1,3 @@
 module AtomicLti
-  VERSION = "1.6.0".freeze
+  VERSION = "1.7.0".freeze
 end

--- a/spec/lib/atomic_lti/lti_spec.rb
+++ b/spec/lib/atomic_lti/lti_spec.rb
@@ -231,6 +231,7 @@ module AtomicLti
       end
 
       it "returns true when target link matches up to host" do
+        previous_setting = AtomicLti.update_target_link_host
         AtomicLti.update_target_link_host = true
         mocks = setup_canvas_lti_advantage do |decoded_id_token|
           decoded_id_token[AtomicLti::Definitions::TARGET_LINK_URI_CLAIM] = "https://example.com/launch?token=1"
@@ -241,6 +242,8 @@ module AtomicLti
         expect {
           Lti.validate!(mocks[:decoded_id_token], "https://other.com/otherlaunch?token=1", true)
         }.to raise_error(AtomicLti::Exceptions::InvalidLTIToken, /doesn't match url/)
+      ensure
+        AtomicLti.update_target_link_host = previous_setting
       end
     end
 

--- a/spec/lib/atomic_lti/lti_spec.rb
+++ b/spec/lib/atomic_lti/lti_spec.rb
@@ -204,6 +204,44 @@ module AtomicLti
         valid = Lti.validate!(mocks[:decoded_id_token])
         expect(valid).to eq(true)
       end
+
+      it "returns true when target link is valid" do
+        mocks = setup_canvas_lti_advantage do |decoded_id_token|
+          decoded_id_token[AtomicLti::Definitions::TARGET_LINK_URI_CLAIM] = "https://example.com/launch?token=1"
+          { decoded_id_token: decoded_id_token }
+        end
+        valid = Lti.validate!(mocks[:decoded_id_token], "https://example.com/launch?token=1", true)
+        expect(valid).to eq(true)
+      end
+
+      it "throws an error when target link is invalid" do
+        mocks = setup_canvas_lti_advantage do |decoded_id_token|
+          decoded_id_token[AtomicLti::Definitions::TARGET_LINK_URI_CLAIM] = "https://example.com/launch?token=1"
+          { decoded_id_token: decoded_id_token }
+        end
+        expect {
+          Lti.validate!(mocks[:decoded_id_token], "https://example.com/launch?token=2", true)
+        }.to raise_error(AtomicLti::Exceptions::InvalidLTIToken, /doesn't match url/)
+        expect {
+          Lti.validate!(mocks[:decoded_id_token], "https://example.com/newlaunch?token=1", true)
+        }.to raise_error(AtomicLti::Exceptions::InvalidLTIToken, /doesn't match url/)
+        expect {
+          Lti.validate!(mocks[:decoded_id_token], "https://other.example.com/launch?token=1#frag", true)
+        }.to raise_error(AtomicLti::Exceptions::InvalidLTIToken, /doesn't match url/)
+      end
+
+      it "returns true when target link matches up to host" do
+        AtomicLti.update_target_link_host = true
+        mocks = setup_canvas_lti_advantage do |decoded_id_token|
+          decoded_id_token[AtomicLti::Definitions::TARGET_LINK_URI_CLAIM] = "https://example.com/launch?token=1"
+          { decoded_id_token: decoded_id_token }
+        end
+        valid = Lti.validate!(mocks[:decoded_id_token], "https://other.com/launch?token=1", true)
+        expect(valid).to eq(true)
+        expect {
+          Lti.validate!(mocks[:decoded_id_token], "https://other.com/otherlaunch?token=1", true)
+        }.to raise_error(AtomicLti::Exceptions::InvalidLTIToken, /doesn't match url/)
+      end
     end
 
     describe "client_id" do

--- a/spec/middleware/open_id_middleware_spec.rb
+++ b/spec/middleware/open_id_middleware_spec.rb
@@ -271,6 +271,19 @@ module AtomicLti
         expect(response[0]).to match('<form action="http://atomicjolt-test.atomicjolt.xyz/lti_launches" method="POST">')
         expect(response[0]).not_to match('<input type="hidden" name="redirect"')
       end
+
+      it "updates the target uri host" do
+        AtomicLti.oidc_redirect_path = "/oidc/redirect?redirect=1"
+        AtomicLti.update_target_link_host = true
+        mocks = setup_canvas_lti_advantage
+        req_env = Rack::MockRequest.env_for(
+          "https://new-test.atomicjolt.xyz/oidc/redirect?redirect=1",
+          { method: "POST", params: mocks[:params] },
+        )
+        status, _headers, response = subject.call(req_env)
+        expect(status).to eq(200)
+        expect(response[0]).to match('<form action="http://new-test.atomicjolt.xyz/lti_launches" method="POST">')
+      end
     end
 
     describe "lti deep link launches" do

--- a/spec/middleware/open_id_middleware_spec.rb
+++ b/spec/middleware/open_id_middleware_spec.rb
@@ -273,6 +273,7 @@ module AtomicLti
       end
 
       it "updates the target uri host" do
+        previous_setting = AtomicLti.update_target_link_host
         AtomicLti.oidc_redirect_path = "/oidc/redirect?redirect=1"
         AtomicLti.update_target_link_host = true
         mocks = setup_canvas_lti_advantage
@@ -283,6 +284,8 @@ module AtomicLti
         status, _headers, response = subject.call(req_env)
         expect(status).to eq(200)
         expect(response[0]).to match('<form action="http://new-test.atomicjolt.xyz/lti_launches" method="POST">')
+      ensure
+        AtomicLti.update_target_link_host = previous_setting
       end
     end
 


### PR DESCRIPTION
This change allows us to support launches to a single tool install across multiple hosts.  Without these changes state validation will fail when the target link host is different from the init/redirect host.