### PR TITLE
Fix UTF-8 characters in LTI params

### DIFF
--- a/app/views/atomic_lti/shared/redirect.html.erb
+++ b/app/views/atomic_lti/shared/redirect.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet">
     <%= stylesheet_link_tag "atomic_lti/launch" %>
   </head>
@@ -13,7 +14,7 @@
           </p>
         </div>
       </noscript>
-      <form action="<%= @launch_url -%>" method="POST">
+      <form action="<%= @launch_url -%>" method="POST" accept-charset="UTF-8">
         <% @launch_params.each do |name, value| -%>
           <%= hidden_field_tag(name, value) %>
         <% end -%>

--- a/spec/middleware/open_id_middleware_spec.rb
+++ b/spec/middleware/open_id_middleware_spec.rb
@@ -153,7 +153,7 @@ module AtomicLti
         )
         status, _headers, response = subject.call(req_env)
         expect(status).to eq(200)
-        expect(response[0]).to match('<form action="http://atomicjolt-test.atomicjolt.xyz/lti_launches" method="POST">')
+        expect(response[0]).to match('<form action="http://atomicjolt-test.atomicjolt.xyz/lti_launches" method="POST"')
       end
 
       it "passes lti storage params" do
@@ -268,7 +268,7 @@ module AtomicLti
         )
         status, _headers, response = subject.call(req_env)
         expect(status).to eq(200)
-        expect(response[0]).to match('<form action="http://atomicjolt-test.atomicjolt.xyz/lti_launches" method="POST">')
+        expect(response[0]).to match('<form action="http://atomicjolt-test.atomicjolt.xyz/lti_launches" method="POST"')
         expect(response[0]).not_to match('<input type="hidden" name="redirect"')
       end
 
@@ -283,7 +283,7 @@ module AtomicLti
         )
         status, _headers, response = subject.call(req_env)
         expect(status).to eq(200)
-        expect(response[0]).to match('<form action="http://new-test.atomicjolt.xyz/lti_launches" method="POST">')
+        expect(response[0]).to match('<form action="http://new-test.atomicjolt.xyz/lti_launches" method="POST"')
       ensure
         AtomicLti.update_target_link_host = previous_setting
       end
@@ -301,7 +301,7 @@ module AtomicLti
         status, _headers, response = subject.call(req_env)
 
         expect(status).to eq(200)
-        expect(response[0]).to match('<form action="http://atomicjolt-test.atomicjolt.xyz/lti_launches" method="POST">')
+        expect(response[0]).to match('<form action="http://atomicjolt-test.atomicjolt.xyz/lti_launches" method="POST"')
       end
 
       it "LTI launches" do


### PR DESCRIPTION
Without this the UTF-8 characters would get mangled when the form was submitted, resulting in Rails throwing an ActionController::BadRequest: Invalid request parameters: Invalid encoding for parameter error

This should fix https://www.pivotaltracker.com/story/show/187213842