### PR TITLE
Add storing the authorization server for platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atomic_lti (1.8.2)
+    atomic_lti (1.8.3)
       pg (~> 1.3)
       rails (~> 7.0)
 

--- a/app/lib/atomic_lti/authorization.rb
+++ b/app/lib/atomic_lti/authorization.rb
@@ -64,7 +64,7 @@ module AtomicLti
       payload = {
         iss:  install.client_id,  # A unique identifier for the entity that issued the JWT
         sub: install.client_id, # "client_id" of the OAuth Client
-        aud: platform.token_url, # Authorization server identifier
+        aud: [platform.authorization_server || platform.token_url], # Authorization server identifier
         iat: Time.now.to_i, # Timestamp for when the JWT was created
         exp: Time.now.to_i + 300, # Timestamp for when the JWT should be treated as having expired
         # (after allowing a margin for clock skew)

--- a/db/migrate/20240612163118_add_platform_authorization_server.rb
+++ b/db/migrate/20240612163118_add_platform_authorization_server.rb
@@ -1,0 +1,5 @@
+class AddPlatformAuthorizationServer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :atomic_lti_platforms, :authorization_server, :string
+  end
+end

--- a/lib/atomic_lti/version.rb
+++ b/lib/atomic_lti/version.rb
@@ -1,3 +1,3 @@
 module AtomicLti
-  VERSION = "1.8.2".freeze
+  VERSION = "1.8.3".freeze
 end


### PR DESCRIPTION
We can receive an authorization server variable in dynamic registration, and we're supposed to use it as the aud value. All of the examples also always send the aud as an array, and while v1.0 of the 1edtech security framework doesn't specify that it always be an array, v1.1 does require it to always be an array.