### PR TITLE
Fix race condition when creating Context records

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atomic_lti (1.8.4)
+    atomic_lti (1.8.5)
       pg (~> 1.3)
       rails (~> 7.0)
 

--- a/lib/atomic_lti/version.rb
+++ b/lib/atomic_lti/version.rb
@@ -1,3 +1,3 @@
 module AtomicLti
-  VERSION = "1.8.4".freeze
+  VERSION = "1.8.5".freeze
 end


### PR DESCRIPTION
If we have concurrent launches we could try to create multiple in parallel and one would succeed and the others could fail.