### PR TITLE
Bump ruby versions in github actions and rubocop

### DIFF
--- a/.github/workflows/github-actions-ci-lint.yml
+++ b/.github/workflows/github-actions-ci-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.7]
+        ruby-version: [3.2]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/github-actions-ci-rspec.yml
+++ b/.github/workflows/github-actions-ci-rspec.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.0, 3.1, 3.2, 3.3]
+        ruby-version: [3.2]
 
     # Service containers to run with `container-job`
     services:

--- a/.github/workflows/github-actions-ci-rspec.yml
+++ b/.github/workflows/github-actions-ci-rspec.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.7]
+        ruby-version: [3.0, 3.1, 3.2, 3.3]
 
     # Service containers to run with `container-job`
     services:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   Exclude:
     - db/schema.rb
     - config/initializers/devise.rb


### PR DESCRIPTION
This matches the current .tool-versions file