### PR TITLE
Add Platform Notification Service

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atomic_lti (1.9.0)
+    atomic_lti (1.10.0)
       pg (~> 1.3)
       rails (~> 7.0)
 

--- a/app/lib/atomic_lti/definitions.rb
+++ b/app/lib/atomic_lti/definitions.rb
@@ -49,7 +49,7 @@ module AtomicLti
     AGS_SCOPE_SCORE = "https://purl.imsglobal.org/spec/lti-ags/scope/score".freeze
     NAMES_AND_ROLES_SCOPE = "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly".freeze
     CALIPER_SCOPE = "https://purl.imsglobal.org/spec/lti-ces/v1p0/scope/send".freeze
-    PNS_SCOPE_NOTICEHANDLERS = "https://purl.imsglobal.org/spec/lti-pns/scope/noticehandlers"
+    PNS_SCOPE_NOTICEHANDLERS = "https://purl.imsglobal.org/spec/lti/scope/noticehandlers".freeze
 
     STUDENT_SCOPE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student".freeze
     INSTRUCTOR_SCOPE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor".freeze

--- a/app/lib/atomic_lti/definitions.rb
+++ b/app/lib/atomic_lti/definitions.rb
@@ -31,6 +31,12 @@ module AtomicLti
 
     NAMES_AND_ROLES_SERVICE_VERSIONS = ["2.0"].freeze
 
+    PLATFORM_NOTIFICATION_SERVICE_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/platformnotificationservice".freeze
+    PLATFORM_NOTIFICATION_SERVICE_VERSIONS = ["1.0".freeze].freeze
+    NOTICE_TYPE_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/notice_type".freeze
+    PLATFORM_NOTIFICATION_CONTEXT_COPY_NOTICE = "LtiContextCopyNotice".freeze
+    PLATFORM_NOTIFICATION_CONTEXT_COPY_ORIGINS_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/origin_contexts".freeze
+
     CALIPER_CLAIM = "https://purl.imsglobal.org/spec/lti-ces/claim/caliper-endpoint-service".freeze
 
     TOOL_LAUNCH_CALIPER_CONTEXT = "http://purl.imsglobal.org/ctx/caliper/v1p1/ToolLaunchProfile-extension".freeze
@@ -43,6 +49,7 @@ module AtomicLti
     AGS_SCOPE_SCORE = "https://purl.imsglobal.org/spec/lti-ags/scope/score".freeze
     NAMES_AND_ROLES_SCOPE = "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly".freeze
     CALIPER_SCOPE = "https://purl.imsglobal.org/spec/lti-ces/v1p0/scope/send".freeze
+    PNS_SCOPE_NOTICEHANDLERS = "https://purl.imsglobal.org/spec/lti-pns/scope/noticehandlers"
 
     STUDENT_SCOPE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student".freeze
     INSTRUCTOR_SCOPE = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor".freeze

--- a/app/lib/atomic_lti/exceptions.rb
+++ b/app/lib/atomic_lti/exceptions.rb
@@ -13,7 +13,7 @@ module AtomicLti
 
     class NamesAndRolesError < AtomicLtiException
     end
-    
+
     class PlatformNotificationsError < AtomicLtiException; end
 
     class ScoreError < AtomicLtiException
@@ -100,7 +100,7 @@ module AtomicLti
 
     class PaginationLimitExceeded < AtomicLtiException
     end
-    
+
     class InvalidPlatformNotification < AtomicLtiException; end
   end
 end

--- a/app/lib/atomic_lti/exceptions.rb
+++ b/app/lib/atomic_lti/exceptions.rb
@@ -13,6 +13,8 @@ module AtomicLti
 
     class NamesAndRolesError < AtomicLtiException
     end
+    
+    class PlatformNotificationsError < AtomicLtiException; end
 
     class ScoreError < AtomicLtiException
     end
@@ -98,5 +100,7 @@ module AtomicLti
 
     class PaginationLimitExceeded < AtomicLtiException
     end
+    
+    class InvalidPlatformNotification < AtomicLtiException; end
   end
 end

--- a/app/lib/atomic_lti/services/platform_notifications.rb
+++ b/app/lib/atomic_lti/services/platform_notifications.rb
@@ -23,10 +23,10 @@ module AtomicLti
       end
 
       def self.enabled?(id_token_decoded)
-        return false unless id_token_decoded&.dig(PLATFORM_NOTIFICATION_SERVICE_CLAIM)
+        return false unless id_token_decoded&.dig(AtomicLti::Definitions::PLATFORM_NOTIFICATION_SERVICE_CLAIM)
 
-        (PLATFORM_NOTIFICATION_SERVICE_VERSIONS &
-          (id_token_decoded.dig(PLATFORM_NOTIFICATION_SERVICE_CLAIM, "service_versions") || [])).present?
+        (AtomicLti::Definitions::PLATFORM_NOTIFICATION_SERVICE_VERSIONS &
+          (id_token_decoded.dig(AtomicLti::Definitions::PLATFORM_NOTIFICATION_SERVICE_CLAIM, "service_versions") || [])).present?
       end
 
       def valid?

--- a/app/lib/atomic_lti/services/platform_notifications.rb
+++ b/app/lib/atomic_lti/services/platform_notifications.rb
@@ -1,17 +1,13 @@
 module AtomicLti
   module Services
     class PlatformNotifications < AtomicLti::Services::Base
-      def initialize(id_token_decoded:)
-        super(id_token_decoded: id_token_decoded)
-      end
-
       def scopes
         [AtomicLti::Definitions::PNS_SCOPE_NOTICEHANDLERS]
       end
 
       def endpoint
         url = @id_token_decoded.dig(AtomicLti::Definitions::PLATFORM_NOTIFICATION_SERVICE_CLAIM, "platform_notification_service_url")
-        raise AtomicLti::Exceptions::PlatformNotificationsError, "Unable to access platform notifications" unless url.present?
+        raise AtomicLti::Exceptions::PlatformNotificationsError, "Unable to access platform notifications" if url.blank?
 
         url
       end
@@ -77,17 +73,17 @@ module AtomicLti
 
         if decoded_token[AtomicLti::Definitions::DEPLOYMENT_ID].blank?
           errors.push(
-            "LTI token is missing required field #{AtomicLti::Definitions::DEPLOYMENT_ID}"
+            "LTI token is missing required field #{AtomicLti::Definitions::DEPLOYMENT_ID}",
           )
         end
 
         if decoded_token[AtomicLti::Definitions::NOTICE_TYPE_CLAIM].blank?
           errors.push(
-            "LTI token is missing required claim #{AtomicLti::Definitions::NOTICE_TYPE}"
+            "LTI token is missing required claim #{AtomicLti::Definitions::NOTICE_TYPE}",
           )
         end
 
-        if errors.length > 0
+        if errors.present?
           raise Exceptions::InvalidPlatformNotification.new(errors.join(" "))
         end
 

--- a/app/lib/atomic_lti/services/platform_notifications.rb
+++ b/app/lib/atomic_lti/services/platform_notifications.rb
@@ -79,7 +79,7 @@ module AtomicLti
 
         if decoded_token[AtomicLti::Definitions::NOTICE_TYPE_CLAIM].blank?
           errors.push(
-            "LTI token is missing required claim #{AtomicLti::Definitions::NOTICE_TYPE}",
+            "LTI token is missing required claim #{AtomicLti::Definitions::NOTICE_TYPE_CLAIM}",
           )
         end
 

--- a/app/lib/atomic_lti/services/platform_notifications.rb
+++ b/app/lib/atomic_lti/services/platform_notifications.rb
@@ -33,34 +33,14 @@ module AtomicLti
         self.class.enabled?(@id_token_decoded)
       end
 
-      # List platform notifications
-      def list(query: {}, page_url: nil)
-        url = if page_url.present?
-                page_url
-              else
-                uri = Addressable::URI.parse(endpoint)
-                uri.query_values = (uri.query_values || {}).merge(query)
-                uri.to_str
-              end
-        response, = service_get(
-          url,
-          headers: headers(),
-        )
+      # Get platform notifications
+      def get(query: {})
+        uri = Addressable::URI.parse(endpoint)
+        uri.query_values = (uri.query_values || {}).merge(query)
+        url = uri.to_str
 
-        response
-      end
-
-      def list_all(query: {})
-        page_body = nil
-
-        members = AtomicLti::PagingHelper.paginate_request do |next_link|
-          result_page = list(query: query, page_url: next_link)
-          page_body = JSON.parse(result_page.body)
-          [page_body["members"], get_next_url(result_page)]
-        end
-
-        page_body["members"] = members
-        page_body
+        response, = service_get(url, headers:)
+        response.parsed_response
       end
 
       def update(notice_type, handler)

--- a/app/lib/atomic_lti/services/platform_notifications.rb
+++ b/app/lib/atomic_lti/services/platform_notifications.rb
@@ -62,14 +62,14 @@ module AtomicLti
         page_body["members"] = members
         page_body
       end
-      
+
       def update(notice_type, handler)
         content_type = { "Content-Type" => "application/json" }
         payload = { notice_type:, handler: }
         response, = service_put(endpoint, body: JSON.dump(payload), headers: headers(content_type))
         response
       end
-      
+
       def self.validate_notification(notification)
         decoded_token = AtomicLti::Authorization.validate_token(notification)
         if decoded_token.blank?

--- a/app/lib/atomic_lti/services/platform_notifications.rb
+++ b/app/lib/atomic_lti/services/platform_notifications.rb
@@ -1,0 +1,124 @@
+module AtomicLti
+  module Services
+    class PlatformNotifications < AtomicLti::Services::Base
+      def initialize(id_token_decoded:)
+        super(id_token_decoded: id_token_decoded)
+      end
+
+      def scopes
+        [AtomicLti::Definitions::PNS_SCOPE_NOTICEHANDLERS]
+      end
+
+      def endpoint
+        url = @id_token_decoded.dig(AtomicLti::Definitions::PLATFORM_NOTIFICATION_SERVICE_CLAIM, "platform_notification_service_url")
+        raise AtomicLti::Exceptions::PlatformNotificationsError, "Unable to access platform notifications" unless url.present?
+
+        url
+      end
+
+      def url_for(query = nil)
+        url = endpoint.dup
+        url << "?#{query}" if query.present?
+        url
+      end
+
+      def self.enabled?(id_token_decoded)
+        return false unless id_token_decoded&.dig(PLATFORM_NOTIFICATION_SERVICE_CLAIM)
+
+        (PLATFORM_NOTIFICATION_SERVICE_VERSIONS &
+          (id_token_decoded.dig(PLATFORM_NOTIFICATION_SERVICE_CLAIM, "service_versions") || [])).present?
+      end
+
+      def valid?
+        self.class.enabled?(@id_token_decoded)
+      end
+
+      # List platform notifications
+      def list(query: {}, page_url: nil)
+        url = if page_url.present?
+                page_url
+              else
+                uri = Addressable::URI.parse(endpoint)
+                uri.query_values = (uri.query_values || {}).merge(query)
+                uri.to_str
+              end
+        response, = service_get(
+          url,
+          headers: headers(),
+        )
+
+        response
+      end
+
+      def list_all(query: {})
+        page_body = nil
+
+        members = AtomicLti::PagingHelper.paginate_request do |next_link|
+          result_page = list(query: query, page_url: next_link)
+          page_body = JSON.parse(result_page.body)
+          [page_body["members"], get_next_url(result_page)]
+        end
+
+        page_body["members"] = members
+        page_body
+      end
+      
+      def update(notice_type, handler)
+        content_type = { "Content-Type" => "application/json" }
+        payload = { notice_type:, handler: }
+        response, = service_put(endpoint, body: JSON.dump(payload), headers: headers(content_type))
+        response
+      end
+      
+      def self.validate_notification(notification)
+        decoded_token = AtomicLti::Authorization.validate_token(notification)
+        if decoded_token.blank?
+          raise AtomicLti::Exceptions::InvalidPlatformNotification
+        end
+
+        errors = []
+
+        if decoded_token["iss"].blank?
+          errors.push("LTI token is missing required field iss")
+        end
+
+        if decoded_token["aud"].blank?
+          errors.push("LTI token is missing required field aud")
+        end
+
+        if decoded_token["aud"].is_a?(Array) && decoded_token["aud"].length > 1
+          # OpenID Connect spec specifies the AZP should exist and be an AUD
+          if decoded_token["azp"].blank?
+            errors.push("LTI token has multiple aud and is missing required field azp")
+          elsif decoded_token["aud"].exclude?(decoded_token["azp"])
+            errors.push("LTI token azp is not one of the aud's")
+          end
+        end
+
+        if decoded_token[AtomicLti::Definitions::DEPLOYMENT_ID].blank?
+          errors.push(
+            "LTI token is missing required field #{AtomicLti::Definitions::DEPLOYMENT_ID}"
+          )
+        end
+
+        if decoded_token[AtomicLti::Definitions::NOTICE_TYPE_CLAIM].blank?
+          errors.push(
+            "LTI token is missing required claim #{AtomicLti::Definitions::NOTICE_TYPE}"
+          )
+        end
+
+        if errors.length > 0
+          raise Exceptions::InvalidPlatformNotification.new(errors.join(" "))
+        end
+
+        if decoded_token[AtomicLti::Definitions::LTI_VERSION].blank?
+          raise AtomicLti::Exceptions::NoLTIVersion
+        end
+
+        raise AtomicLti::Exceptions::InvalidLTIVersion unless AtomicLti::Lti.valid_version?(decoded_token)
+
+        decoded_token
+      end
+    end
+  end
+end

--- a/lib/atomic_lti/version.rb
+++ b/lib/atomic_lti/version.rb
@@ -1,3 +1,3 @@
 module AtomicLti
-  VERSION = "1.9.0".freeze
+  VERSION = "1.10.0".freeze
 end

--- a/spec/lib/atomic_lti/services/platform_notifications_spec.rb
+++ b/spec/lib/atomic_lti/services/platform_notifications_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe AtomicLti::Services::PlatformNotifications do
     it "updates the platform notifications" do
       pns_service = AtomicLti::Services::PlatformNotifications.new(id_token_decoded: @id_token_decoded)
       response = pns_service.update("notice_type", "handler")
-      expect(response.parsed_response).to be_present 
+      expect(response.parsed_response).to be_present
     end
   end
 end

--- a/spec/lib/atomic_lti/services/platform_notifications_spec.rb
+++ b/spec/lib/atomic_lti/services/platform_notifications_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe AtomicLti::Services::PlatformNotifications do
+  before do
+    setup_canvas_lti_advantage
+    @id_token_decoded = AtomicLti::Authorization.validate_token(@params["id_token"])
+    # mock all requests to get a token
+    stub_token_create
+  end
+
+  describe "valid?" do
+    it "indicates if the launch contains the names and roles scope" do
+      pns_service = AtomicLti::Services::PlatformNotifications.new(id_token_decoded: @id_token_decoded)
+      expect(pns_service.valid?).to eq true
+    end
+  end
+
+  describe "list" do
+    before do
+      stub_platform_notifications_get
+    end
+
+    it "requests only the names and roles scope" do
+      expect(AtomicLti::Authorization).to receive(:request_token).
+        with(hash_including({ scopes: [AtomicLti::Definitions::PNS_SCOPE_NOTICEHANDLERS] })).
+        and_return("token")
+      pns_service = AtomicLti::Services::PlatformNotifications.new(id_token_decoded: @id_token_decoded)
+      pns_service.get
+    end
+
+    it "gets the platform notifications" do
+      pns_service = AtomicLti::Services::PlatformNotifications.new(id_token_decoded: @id_token_decoded)
+      notifications = pns_service.get
+      expect(notifications["client_id"]).to be_present
+    end
+  end
+
+  describe "update" do
+    before do
+      stub_platform_notifications_put
+    end
+
+    it "updates the platform notifications" do
+      pns_service = AtomicLti::Services::PlatformNotifications.new(id_token_decoded: @id_token_decoded)
+      response = pns_service.update("notice_type", "handler")
+      expect(response.parsed_response).to be_present 
+    end
+  end
+end

--- a/spec/support/http_mocks.rb
+++ b/spec/support/http_mocks.rb
@@ -142,3 +142,19 @@ def stub_scores_create
       body: "{\"resultUrl\":\"https://atomicjolt.instructure.com/api/lti/courses/3334/line_items/31/results/4\"}",
     )
 end
+
+def stub_platform_notifications_get
+  stub_request(:get, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/deployments/[0-9a-z-]+/pns|).
+    to_return(
+      status: 200,
+      body: "{\"client_id\":\"c8b93c66-3cd9-4cd7-976f-9e49ad674a0c\",\"deployment_id\":\"d8d80f67-4def-46ea-9bed-ddd1151e5e6b\",\"notice_handlers\":[{\"notice_type\":\"LtiContextCopyNotice\",\"handler\":\"https://atomicjournalsds.atomicjolt.win/lti_platform_notifications\"}]}",
+    )
+end
+
+def stub_platform_notifications_put
+  stub_request(:put, %r|https*://[a-zA-Z0-9]+\.[a-zA-Z0-9]+.*com/api/lti/deployments/[0-9a-z-]+/pns|).
+    to_return(
+      status: 200,
+      body: "{\"client_id\":\"c8b93c66-3cd9-4cd7-976f-9e49ad674a0c\",\"deployment_id\":\"d8d80f67-4def-46ea-9bed-ddd1151e5e6b\",\"notice_handlers\":[{\"notice_type\":\"LtiContextCopyNotice\",\"handler\":\"https://atomicjournalsds.atomicjolt.win/lti_platform_notifications\"}]}",
+    )
+end

--- a/spec/support/lti_advantage_helper.rb
+++ b/spec/support/lti_advantage_helper.rb
@@ -192,6 +192,17 @@ def deep_link_settings_claim
   }
 end
 
+def platform_notification_claim
+  {
+    "https://purl.imsglobal.org/spec/lti/claim/platformnotificationservice": {
+      "platform_notification_service_url": "https://atomicjolt.instructure.com/api/lti/deployments/d8d80f67-4def-46ea-9bed-ddd1151e5e6b/pns",
+      "service_versions": ["1.0"],
+      "scope": ["https://purl.imsglobal.org/spec/lti/scope/noticehandlers"],
+      "notice_types_supported": ["LtiContextCopyNotice"],
+    },
+  }
+end
+
 def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:, resource_link_id:, deployment_id:, nonce:)
   exp = 24.hours.from_now
   payload = {
@@ -268,6 +279,7 @@ def build_payload(client_id:, iss:, lti_user_id:, context_id:, message_type:, re
 
   payload.merge!(resource_link_claim(resource_link_id)) if @message_type == "LtiResourceLinkRequest"
   payload.merge!(deep_link_settings_claim) if @message_type == "LtiDeepLinkingRequest"
+  payload.merge!(platform_notification_claim)
 
   payload
 end


### PR DESCRIPTION
This adds a class for interacting with the service and the associated definitions. The application will have to handle actually performing registration, providing an endpoint, and verifying the notifications.