### PR TITLE
add observer context role.

### DIFF
--- a/app/lib/atomic_lti/definitions.rb
+++ b/app/lib/atomic_lti/definitions.rb
@@ -174,6 +174,7 @@ module AtomicLti
 
     OBSERVER_ROLES = [
       MENTOR_INSTITUTION_ROLE,
+      MENTOR_CONTEXT_ROLE,
       # NON_CREDIT_LEARNER,
     ].freeze
 


### PR DESCRIPTION
in 1.3 canvas launches, I was not recognized as an observer with the current list